### PR TITLE
Avoid "too many local variables" error

### DIFF
--- a/Extension/src/runBuild.ts
+++ b/Extension/src/runBuild.ts
@@ -44,6 +44,8 @@ end
 
 local _builder = LifeBoatAPI.Tools.Builder:new(rootDirs, outputDir, luaDocsMCPath, luaDocsAddonPath)
 
+local combinedText, outText, outFile
+
 if onLBBuildStarted then onLBBuildStarted(_builder, params, LifeBoatAPI.Tools.Filepath:new([[${workspace.fsPath}]])) end
 `;
 
@@ -61,8 +63,8 @@ if onLBBuildStarted then onLBBuildStarted(_builder, params, LifeBoatAPI.Tools.Fi
                     relativePath = relativePath.substr(1);
                 }
 
-                let buildLine = isMC ? `local combinedText, outText, outFile = _builder:buildMicrocontroller([[${relativePath}]], LifeBoatAPI.Tools.Filepath:new([[${file.fsPath}]]), params)`
-                                     : `local combinedText, outText, outFile = _builder:buildAddonScript([[${relativePath}]], LifeBoatAPI.Tools.Filepath:new([[${file.fsPath}]]), params)`;
+                let buildLine = isMC ? `combinedText, outText, outFile = _builder:buildMicrocontroller([[${relativePath}]], LifeBoatAPI.Tools.Filepath:new([[${file.fsPath}]]), params)`
+                                     : `combinedText, outText, outFile = _builder:buildAddonScript([[${relativePath}]], LifeBoatAPI.Tools.Filepath:new([[${file.fsPath}]]), params)`;
                 content += `\nif onLBBuildFileStarted then onLBBuildFileStarted(_builder, params, LifeBoatAPI.Tools.Filepath:new([[${workspace.fsPath}]]), [[${relativePath}]], LifeBoatAPI.Tools.Filepath:new([[${file.fsPath}]])) end\n`
                          + `\n${buildLine}`
                          + `\nif onLBBuildFileComplete then onLBBuildFileComplete(LifeBoatAPI.Tools.Filepath:new([[${workspace.fsPath}]]), [[${relativePath}]], LifeBoatAPI.Tools.Filepath:new([[${file.fsPath}]]), outFile, combinedText, outText) end\n`;


### PR DESCRIPTION
Consolidated repeated declarations of a local variable with the same name into a single declaration in `_build.lua`
to avoid error `too many local variables (limit is 200)` when build workspace have more than 64 lua fies.

I'm not sure what side effects this could cause, sorry.