### PR TITLE
Update package.json to auto rollback lua debug

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -27,7 +27,7 @@
   	],
   	"extensionPack": [
   	  	"sumneko.lua",
-  	  	"actboy168.lua-debug"
+  	  	"actboy168.lua-debug":"1.61.0"
   	],
   	"main": "./out/extension.js",
   	"contributes": {


### PR DESCRIPTION
This should fix the Lua debug issue where the user has to roll back to V1.61.0 from the latest when downloading the extension. The extension should now load Lua Debug V1.61.0 by default.