### PR TITLE
Lua Debug fix V2

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -27,7 +27,7 @@
   	],
   	"extensionPack": [
   	  	"sumneko.lua",
-  	  	"actboy168.lua-debug"
+  	  	"actboy168.lua-debug@1.61.0"
   	],
   	"main": "./out/extension.js",
   	"contributes": {


### PR DESCRIPTION
Sets the Lua Debug extension to be downloaded with the main one to be V1.61.0
Should be an easy thing but as this is my first time editing a VSCode Extension I am unaware on how to really do this.

`"actboy168.lua-debug" -->
  "actboy168.lua-debug@1.61.0"`

Resolves #132 #131

@Toast732 If you would please be as so kind as to take a look at this...